### PR TITLE
Nomenclature changes to make nody-greeter compatible with web-greeter

### DIFF
--- a/themes/dracula/ts/backgrounds.ts
+++ b/themes/dracula/ts/backgrounds.ts
@@ -23,7 +23,7 @@ export class Backgrounds {
      * Background change requests are handled via broadcast events so that all
      * windows correctly update.
      */
-    window.addEventListener("NodyBroadcastEvent", (ev) => {
+    window.addEventListener("GreeterBroadcastEvent", (ev) => {
       const data: BackgroundData = ev.data as BackgroundData;
       if (data.type == "change-background") {
         this._backgroundPath = data.path;
@@ -74,8 +74,8 @@ export class Backgrounds {
     for (const path of this._backgroundImages) {
       const button = this.createImageButton(path);
       button.addEventListener("click", () => {
-        if (window.nody_greeter) {
-          window.nody_greeter.broadcast({
+        if (window.greeter_comm) {
+          window.greeter_comm.broadcast({
             type: "change-background",
             path,
           });

--- a/ts/preload.ts
+++ b/ts/preload.ts
@@ -40,14 +40,14 @@ export interface WindowMetadata {
  * An event that is fired and dispatched when one browser window of a theme
  * sends a broadcast to all windows (which happens for multi-monitor setups)
  */
-export class NodyBroadcastEvent extends Event {
+export class GreeterBroadcastEvent extends Event {
   public constructor(
     /** Metadata for the window that originated the request */
     public readonly window: WindowMetadata,
     /** Data sent in the broadcast */
     public readonly data: unknown
   ) {
-    super("NodyBroadcastEvent");
+    super("GreeterBroadcastEvent");
   }
 }
 
@@ -55,7 +55,7 @@ export class NodyBroadcastEvent extends Event {
  * A class that exposes functionality that is unique to `nody-greeter` and not
  * present in `web-greeter`
  */
-export class Nody {
+export class Comm {
   private _window_metadata: WindowMetadata | null = null;
   /**
    * callback that should be called when the metadata is received
@@ -64,7 +64,7 @@ export class Nody {
   private readonly _ready_promise: Promise<void>;
 
   public constructor() {
-    window.nody_greeter = this;
+    window.greeter_comm = this;
 
     ipcRenderer.on(CONSTS.channel.window_metadata, (_ev, metadata) => {
       this._window_metadata = metadata;
@@ -75,13 +75,13 @@ export class Nody {
     ipcRenderer.send(CONSTS.channel.window_metadata);
 
     ipcRenderer.on(CONSTS.channel.window_broadcast, (_ev, metadata, data) => {
-      const event = new NodyBroadcastEvent(metadata, data);
+      const event = new GreeterBroadcastEvent(metadata, data);
       window.dispatchEvent(event);
     });
 
     this._ready_promise = new Promise((resolve) => (this._ready = resolve));
 
-    return window.nody_greeter;
+    return window.greeter_comm;
   }
 
   public get window_metadata(): WindowMetadata {
@@ -936,7 +936,7 @@ export class ThemeUtils {
   }
 }
 
-new Nody();
+new Comm();
 new ThemeUtils();
 new GreeterConfig();
 new Greeter();
@@ -955,13 +955,13 @@ const domLoaded = new Promise<void>((resolve) => {
  * Promise that fires when all initialization has completed,
  * and the theme can start (i.e. _ready_event can be sent)
  */
-const readyPromise = Promise.all([domLoaded, window.nody_greeter?.whenReady()]);
+const readyPromise = Promise.all([domLoaded, window.greeter_comm?.whenReady()]);
 
 readyPromise.then(() => {
   if (window._ready_event) window.dispatchEvent(window._ready_event);
 });
 
-export declare const nody_greeter: Nody;
+export declare const greeter_comm: Comm;
 export declare const lightdm: Greeter;
 export declare const greeter_config: GreeterConfig;
 export declare const theme_utils: ThemeUtils;
@@ -969,15 +969,15 @@ export declare const _ready_event: Event;
 
 declare global {
   interface Window {
-    nody_greeter: Nody | undefined;
+    greeter_comm: Comm | undefined;
     lightdm: Greeter | undefined;
     greeter_config: GreeterConfig | undefined;
     theme_utils: ThemeUtils | undefined;
     _ready_event: Event | undefined;
 
     addEventListener(
-      type: "NodyBroadcastEvent",
-      listener: (ev: NodyBroadcastEvent) => void,
+      type: "GreeterBroadcastEvent",
+      listener: (ev: GreeterBroadcastEvent) => void,
       options?: boolean | AddEventListenerOptions | undefined
     ): void;
 


### PR DESCRIPTION
## Changes

- `NodyBroadcastEvent` renamed to `GreeterBroadcastEvent`
- `Nody` class renamed to `Comm`
- `window.nody_greeter` object renamed to `window.greeter_comm`
- Dracula theme updated to implement this changes

This PR will be merged when web-greeter multi-monitor PR is merged :D